### PR TITLE
proactive refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "shamirs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shamirs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A cryptographic library for splitting a secret into multiple parts and reconstructing it using Shamir's Secret Sharing."
 license = "MPL-2.0"
@@ -17,3 +17,6 @@ zeroize = "1.7.0"
 
 [dev-dependencies]
 hex = "0.4.3"
+
+[features]
+refresh = []

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ShamiRS places strong emphasis on security.
 The original library mentioned in the CVE report `2023-25000` has already mitigated the vulnerability, although it's crucial to exercise caution when using other libraries to verify that they do not utilize precomputed `LOG/EXP` tables, which in this case are susceptible to security vulnerabilities.
 
 ## Acknowledgments
-The current implementation is based on the Golang library developed by Hashicorp. You can find the repository [here](https://github.com/hashicorp/vault/blob/main/shamir/shamir.go).
+The current implementation is based on the Golang library developed by Hashicorp. This version is not meant to mirror the original implementation and there's no affiliation with Hashicorp or Vault. There might be changes and added features. You can find the repository [here](https://github.com/hashicorp/vault/blob/main/shamir/shamir.go).
 
 ## Tests
 Every module has it's own tests located at the end of the file, to execute them run the following command at the root of the repository:  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center"> 
     
-[Overview](#Overview) | [Disclaimer](#Disclaimer) | [Security](#Security) | [Acknowledgments](#Acknowledgments) | [Tests](#Tests) | [Installation](#Installation) | [Usage](#Usage) | [Examples](#Examples) | [License](#License)
+[Overview](#Overview) | [Features](#Features) | [Disclaimer](#Disclaimer) | [Security](#Security) | [Acknowledgments](#Acknowledgments) | [Tests](#Tests) | [Installation](#Installation) | [Usage](#Usage) | [Examples](#Examples) | [License](#License)
 </div>
 
 <div align="center">
@@ -24,6 +24,9 @@ ShamiRS (shamir-rs) utilizes [Sharmir's Secret Sharing](https://en.wikipedia.org
 - **Secret Reconstruction**: When the minimum number of shares (`threshold`)  are gathered, the polynomial can be then reconstructed using Lagrange interpolation. The constant terms of these resulting polynomials would be each byte of the original secret.
 
 A key aspect of this method is that possession of less shares than the required `threshold` amount reveals no information about the secret, which substantially reduces the risk of a single point of failure.
+
+## Features 
+- **Proactive Refresh**: Allows shares to be updated while preserving the original secret, countering perpetual leakage by preventing the accumulation of exposed shares over time. Can be enabled with the `refresh` feature flag. Highly experimental.
 
 ## Disclaimer
 The library has not been subjected to a formal security audit. It should be used at your own discretion and risk. Furthermore, backward compatibility is not guaranteed and the package is intentionally not published on crates.io until and if there's a `stable` release in the future.
@@ -97,19 +100,10 @@ cargo run --example basic -q
 // --example basic: Specifies that you want to run the 'basic' example.
 // -q: Optional flag for quiet mode, which reduces unnecessary output.
 ```
-
-the output should be similar to:
-
-```sh
-share_1: 3b89c1886bf64f60176b2c429d730d3ca13d7f95b0ac380686fe948c5acae113d0
-share_2: 220bd4708ef623b926f361ab0a3be001ed29c4e73ae246cfa84e321f2646430f4f
-share_3: 15c45226d2c8582909cb8472effc35e1188e0321c7d5d7b56b66652839c8bc7555
-share_4: 9fb2d8cf52addd0c5f7a8c35e8b807f94cceeeaa61582ecc062d59da073728f388
-share_5: 099c6e7726618fe38fcdd64173067f18320a8d1d58638b7f83a2471e7bf1472570
-
-initial:   dde23b13ab8bcddaf1ee97bb6206408a1dc9a7bd656e0b96a795ea7cbf27abeb
-recovered: dde23b13ab8bcddaf1ee97bb6206408a1dc9a7bd656e0b96a795ea7cbf27abeb
-the secret was successfully reconstructed.
+For the [refresh example](examples/refresh.rs), run the following command:
+```rust
+// Note: The refresh feature must be enabled.
+cargo run --example refresh --features refresh -q
 ```
 
 ## License

--- a/examples/refresh.rs
+++ b/examples/refresh.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "refresh")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use rand::{prelude::SliceRandom, RngCore};
+    use rand::{thread_rng, RngCore};
     use shamirs::{combine, refresh, split};
 
     /// The total number of shares the secret will be split into.
@@ -8,19 +8,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// The minimum number of shares needed to reconstruct the secret.
     const THRESHOLD: usize = 3;
 
-    // Initialize secret buffer with random bytes
-    let mut original_secret: [u8; 32] = [0; 32];
-    rand::thread_rng().fill_bytes(&mut original_secret);
-
-    println!("secret: {}\n", hex::encode(&original_secret));
-
     // ----------------------------------------
     // --- Stage I: Initial Share Generation --
     // ----------------------------------------
 
+    // Initialize secret buffer with random bytes
+    let mut secret = [0u8; 32];
+    thread_rng().fill_bytes(&mut secret);
+    println!("secret: {}\n", hex::encode(&secret));
+
     // Split the secret into shares
     println!("# initial shares:");
-    let mut initial_shares: Vec<Vec<u8>> = split(&original_secret, NUM_SHARES, THRESHOLD)?;
+    let shares = split(&secret, NUM_SHARES, THRESHOLD)?;
     // This will generate `NUM_SHARES` amount of shares, with their corresponding x-coordinates.
     //      y0   y1   y2   y3   y4   y5   y6   y7   y8   y9  y10  y11  y12  y13   x
     // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -28,20 +27,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // s2 = 46 | 50 | 1f | 7b | 38 | cc | 46 | eb | 90 | dc | a1 | 5e | 37 | 48 | 45
     // ...
 
-    // Randomly shuffle the shares for demonstrational purposes
-    initial_shares.shuffle(&mut rand::thread_rng());
     // Print all shares in hex encoding
-    for (i, share) in initial_shares.iter().enumerate() {
+    for (i, share) in shares.iter().enumerate() {
         println!("share_{}: {}", i + 1, hex::encode(share));
     }
 
     // Combine subset of shares to recover secret
-    let selected_shares: Vec<Vec<u8>> = initial_shares[..THRESHOLD].to_vec();
-    let recovered_secret: Vec<u8> = combine(&selected_shares)?;
-    // Verify that the recovery was successful
-    assert_eq!(original_secret, recovered_secret.as_slice());
+    let recovered = combine(&shares[..THRESHOLD])?;
+    assert_eq!(secret, recovered.as_slice());
 
-    println!("\nrecovered: {}", hex::encode(&recovered_secret));
+    println!("\nrecovered: {}", hex::encode(&recovered));
     println!("secret successfully reconstructed from shares.\n");
 
     // ----------------------------------------
@@ -50,26 +45,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Refresh the shares
     println!("# refreshed shares:");
-    let refreshed_shares = refresh(&initial_shares, THRESHOLD)?;
+    let refreshed = refresh(&shares, THRESHOLD)?;
 
     // Print all refreshed shares in hex encoding
-    for (i, share) in refreshed_shares.iter().enumerate() {
+    for (i, share) in refreshed.iter().enumerate() {
         println!("share_{}: {}", i + 1, hex::encode(share));
     }
 
     // Combine a subset of the refreshed shares to recover the secret
-    let selected_shares: Vec<Vec<u8>> = refreshed_shares[..THRESHOLD].to_vec();
-    let final_secret = combine(&selected_shares)?;
-
-    // Verify that the refreshed shares can reconstruct to the original secret
-    assert_eq!(original_secret, final_secret.as_slice());
+    let final_secret = combine(&refreshed[..THRESHOLD])?;
+    assert_eq!(secret, final_secret.as_slice());
 
     println!("\nrecovered: {}", hex::encode(&final_secret));
     println!("secret successfully reconstructed from refreshed shares.");
 
     Ok(())
 }
-
 
 // Fallback function if the refresh feature is not enabled
 #[cfg(not(feature = "refresh"))]

--- a/examples/refresh.rs
+++ b/examples/refresh.rs
@@ -1,0 +1,83 @@
+#[cfg(feature = "refresh")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use rand::{prelude::SliceRandom, RngCore};
+    use shamirs::{combine, refresh, split};
+
+    /// The total number of shares the secret will be split into.
+    const NUM_SHARES: usize = 5;
+    /// The minimum number of shares needed to reconstruct the secret.
+    const THRESHOLD: usize = 3;
+
+    // Initialize secret buffer with random bytes
+    let mut original_secret: [u8; 32] = [0; 32];
+    rand::thread_rng().fill_bytes(&mut original_secret);
+
+    println!("secret: {}\n", hex::encode(&original_secret));
+
+    // ----------------------------------------
+    // --- Stage I: Initial Share Generation --
+    // ----------------------------------------
+
+    // Split the secret into shares
+    println!("# initial shares:");
+    let mut initial_shares: Vec<Vec<u8>> = split(&original_secret, NUM_SHARES, THRESHOLD)?;
+    // This will generate `NUM_SHARES` amount of shares, with their corresponding x-coordinates.
+    //      y0   y1   y2   y3   y4   y5   y6   y7   y8   y9  y10  y11  y12  y13   x
+    // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+    // s1 = 67 | 7c | cf | fd | 45 | 77 | 67 | fe | db | a2 | d9 | 62 | 0b | c2 | 82
+    // s2 = 46 | 50 | 1f | 7b | 38 | cc | 46 | eb | 90 | dc | a1 | 5e | 37 | 48 | 45
+    // ...
+
+    // Randomly shuffle the shares for demonstrational purposes
+    initial_shares.shuffle(&mut rand::thread_rng());
+    // Print all shares in hex encoding
+    for (i, share) in initial_shares.iter().enumerate() {
+        println!("share_{}: {}", i + 1, hex::encode(share));
+    }
+
+    // Combine subset of shares to recover secret
+    let selected_shares: Vec<Vec<u8>> = initial_shares[..THRESHOLD].to_vec();
+    let recovered_secret: Vec<u8> = combine(&selected_shares)?;
+    // Verify that the recovery was successful
+    assert_eq!(original_secret, recovered_secret.as_slice());
+
+    println!("\nrecovered: {}", hex::encode(&recovered_secret));
+    println!("secret successfully reconstructed from shares.\n");
+
+    // ----------------------------------------
+    // ---   Stage II: Proactive Refresh    ---
+    // ----------------------------------------
+
+    // Refresh the shares
+    println!("# refreshed shares:");
+    // This will generate `NUM_SHARES` amount of refreshed keys and add them to the shares.
+    // refresh_key_1: 5c2664145242d8eb43912084e0ef869ac50a9903ac611415b5f53e73440fa88f
+    // refresh_key_2: ...
+    // ...
+    let refreshed_shares = refresh(&initial_shares, THRESHOLD)?;
+
+    // Print all refreshed shares in hex encoding
+    for (i, share) in refreshed_shares.iter().enumerate() {
+        println!("share_{}: {}", i + 1, hex::encode(share));
+    }
+
+    // Combine a subset of the refreshed shares to recover the secret
+    let selected_shares: Vec<Vec<u8>> = refreshed_shares[..THRESHOLD].to_vec();
+    let final_secret = combine(&selected_shares)?;
+
+    // Verify that the refreshed shares can reconstruct to the original secret
+    assert_eq!(original_secret, final_secret.as_slice());
+
+    println!("\nrecovered: {}", hex::encode(&final_secret));
+    println!("secret successfully reconstructed from refreshed shares.");
+
+    Ok(())
+}
+
+
+// Fallback function if the refresh feature is not enabled
+#[cfg(not(feature = "refresh"))]
+fn main() {
+    println!("refresh feature is not enabled");
+    println!("use: cargo run --example refresh --features refresh -q");
+}

--- a/examples/refresh.rs
+++ b/examples/refresh.rs
@@ -50,10 +50,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Refresh the shares
     println!("# refreshed shares:");
-    // This will generate `NUM_SHARES` amount of refreshed keys and add them to the shares.
-    // refresh_key_1: 5c2664145242d8eb43912084e0ef869ac50a9903ac611415b5f53e73440fa88f
-    // refresh_key_2: ...
-    // ...
     let refreshed_shares = refresh(&initial_shares, THRESHOLD)?;
 
     // Print all refreshed shares in hex encoding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@ pub fn split(secret: &[u8], parts: usize, threshold: usize) -> Result<Vec<Vec<u8
     Ok(shares)
 }
 
-
 /// Generates update keys and refreshes the shares
 ///
 /// ## Arguments


### PR DESCRIPTION
# Shamirs v0.2.0

## Description
Add a new `refresh` feature, examples and keep it under a feature flag. This is an experimental feature. Do not use in production.

## User Features 
- The `refresh` feature allows users to implement proactive refresh and update their shares without the need to combine them or change the secret.

## File changes
- `src/lib.rs`: implementation of the `refresh` feature together with tests.
- `examples/refresh.rs`: example with comments to guide users to understand proactive refresh
- `README.md`: updated Readme to reflect the new changes on `lib.rs` and inform about the new `refresh` feature.
- `Cargo.toml`: bumped version to 0.2.0, added new feature flag